### PR TITLE
Typo: leaf key instead of root key

### DIFF
--- a/src/Data/LCA/Online.hs
+++ b/src/Data/LCA/Online.hs
@@ -218,7 +218,7 @@ isAncestorOf xs ys = xs ~= keep (length xs) ys
 {-# INLINE isAncestorOf #-}
 
 infix 4 ~=
--- | /O(1)/ Compare to see if two trees have the same leaf key
+-- | /O(1)/ Compare to see if two trees have the same root key
 (~=) :: Path a -> Path b -> Bool
 Nil          ~= Nil          = True
 Cons _ _ s _ ~= Cons _ _ t _ = sameT s t

--- a/src/Data/LCA/Online/Monoidal.hs
+++ b/src/Data/LCA/Online/Monoidal.hs
@@ -287,7 +287,7 @@ isAncestorOf :: Monoid b => Path a -> Path b -> Bool
 isAncestorOf xs ys = xs ~= keep (length xs) ys
 
 infix 4 ~=
--- | /O(1)/ Compare to see if two trees have the same leaf key
+-- | /O(1)/ Compare to see if two trees have the same root key
 (~=) :: Path a -> Path b -> Bool
 Nil            ~= Nil            = True
 Cons _ _ _ s _ ~= Cons _ _ _ t _ = sameT s t

--- a/src/Data/LCA/Online/Naive.hs
+++ b/src/Data/LCA/Online/Naive.hs
@@ -134,7 +134,7 @@ isAncestorOf xs ys = xs ~= keep (length xs) ys
 {-# INLINE isAncestorOf #-}
 
 infix 4 ~=
--- | /O(1)/ Compare to see if two trees have the same leaf key
+-- | /O(1)/ Compare to see if two trees have the same root key
 (~=) :: Path a -> Path b -> Bool
 Path _ []        ~= Path _ []        = True
 Path _ ((i,_):_) ~= Path _ ((j,_):_) = i == j


### PR DESCRIPTION
Hello! 
I think there's a typo in the description of the `~=` operator: the docs say that it checks whether the two trees have the same leaf, but the `sameT` checks for root equality.

It's an awesome library btw! I'm trying to formalize the algorithms here as a part of a homework for Isabelle/HOL.